### PR TITLE
Add AuthenticateGuard for state protected

### DIFF
--- a/src/components/auth/signin/signin.js
+++ b/src/components/auth/signin/signin.js
@@ -12,6 +12,7 @@ const route = $stateProvider => {
     template: SigninTemplate,
     controller: SignInController,
     controllerAs: 'signin',
+    noAuth: true,
   });
 };
 

--- a/src/components/auth/signup/signup.js
+++ b/src/components/auth/signup/signup.js
@@ -11,6 +11,7 @@ const route = $stateProvider => {
     template: SignupTemplate,
     controller: 'SignUpController',
     controllerAs: 'signup',
+    noAuth: true,
   });
 };
 

--- a/src/components/notFound/notFound.js
+++ b/src/components/notFound/notFound.js
@@ -7,6 +7,7 @@ const route = $stateProvider => {
   $stateProvider.state('notFound', {
     url: '/404',
     template: NotFoundTemplate,
+    noAuth: true,
   });
 };
 

--- a/src/config/AuthenticateGuard.js
+++ b/src/config/AuthenticateGuard.js
@@ -1,0 +1,18 @@
+/** @ngInject */
+export default ($rootScope, $state, $auth, $toast, $timeout) => {
+  $rootScope.$on('$stateChangeStart', (event, next) => {
+    if (next.noAuth) {
+      if ($auth.isAuthenticated()) {
+        event.preventDefault();
+        $timeout(() => $state.go('dashboard'), 0);
+      }
+      return;
+    }
+
+    if (! $auth.isAuthenticated()) {
+      event.preventDefault();
+      $toast.show('You should Login!');
+      $timeout(() => $state.go('auth.signin'), 0);
+    }
+  });
+};

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -3,6 +3,7 @@ import router from './router.config';
 import translate from './translate.config';
 import satellizer from './satellizer.config';
 import material from './material.config';
+import authenticateGuard from './AuthenticateGuard';
 
 const Config = module('app.config', [])
   .config(router)
@@ -11,6 +12,7 @@ const Config = module('app.config', [])
   .config(material)
   .constant('Config', {
     API_URL: 'http://163.17.136.83:8080/api',
-  });
+  })
+  .run(authenticateGuard);
 
 export default Config.name;


### PR DESCRIPTION
A Guard means a user can't enter into a need auth state when that aren't logged in
(when the state config hasn't a `noAuth` property).
If the user is logged in, so that can't enter into a state that are should not logged in
(when the state config has a `noAuth` property).
- Add AuthenticateGuard for state auth when `$stateChangeState` are fired
