### PR TITLE
Fix bucket checked status

### DIFF
--- a/src/components/bucket/bucket.service.js
+++ b/src/components/bucket/bucket.service.js
@@ -147,6 +147,7 @@ export default class BucketService {
       })
       .finally(() => {
         this.closeDialog();
+        this.state.create.checked = false;
       });
   }
 }


### PR DESCRIPTION
The `state.create.checked` should be reset after the bucket are created.
