### PR TITLE
Fix loop error of AuthenticateGuard

### DIFF
--- a/src/config/AuthenticateGuard.js
+++ b/src/config/AuthenticateGuard.js
@@ -1,5 +1,5 @@
 /** @ngInject */
-export default ($rootScope, $state, $auth, $toast, $timeout) => {
+export default ($rootScope, $state, $auth, $toast) => {
   $rootScope.$on('$stateChangeStart', (event, next) => {
     if (next.noAuth) {
       if ($auth.isAuthenticated()) {
@@ -18,7 +18,7 @@ export default ($rootScope, $state, $auth, $toast, $timeout) => {
 
   $rootScope.$on('$routeChangeError', ($event, current, previous, rejection) => {
     if (rejection.status === 404) {
-      $timeout(() => $state.go('404'), 0);
+      $state.go('404');
     }
   });
 };

--- a/src/config/AuthenticateGuard.js
+++ b/src/config/AuthenticateGuard.js
@@ -4,15 +4,15 @@ export default ($rootScope, $state, $auth, $toast, $timeout) => {
     if (next.noAuth) {
       if ($auth.isAuthenticated()) {
         event.preventDefault();
-        $timeout(() => $state.go('bucket'), 0);
+        $state.go('bucket');
       }
       return;
     }
 
     if (! $auth.isAuthenticated()) {
       event.preventDefault();
+      $state.go('auth.signin');
       $toast.show('You should Login!');
-      $timeout(() => $state.go('auth.signin'), 0);
     }
   });
 


### PR DESCRIPTION
The console will get following message when user want to enter a need authenticated route without signed in.

```
10 $digest() iterations reached. Aborting!
10 $digest() iterations reached. Aborting!
10 $digest() iterations reached. Aborting!
```

The cause of this error is because the `$timeout` method will break when the UI are initialized.
To fix it, I try to remove the `$timeout` method and it still works without the error.
