### PR TITLE
Bucket check state should reset when the dialog are closed

### DIFF
--- a/src/components/bucket/bucket.service.js
+++ b/src/components/bucket/bucket.service.js
@@ -70,6 +70,7 @@ export default class BucketService {
    */
   closeDialog() {
     this.$mdDialog.cancel();
+    this.resetCheckBucketState();
   }
 
   /**
@@ -147,7 +148,6 @@ export default class BucketService {
       })
       .finally(() => {
         this.closeDialog();
-        this.state.create.checked = false;
       });
   }
 }


### PR DESCRIPTION
In #44, I fix the check state after the bucket created, but the check
state won't reset when the user close the dialog without create.
- Delete the checked assignment in `createBucket()`
- Add `resetCheckBucketState()` called to `closeDialog()`
